### PR TITLE
Support service name in global header

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ that can be overridden or extended from your template:
   - `body_skiplinks` - wraps container with "skip to content" link (first element inside `body`)
   - `body_notifications` - wraps cookie message container (above `site_header`, after `skiplinks`)
   - `body_site_header` - wraps site header
+  - `body_site_header_service_title` - wraps the service title
   - `body_main_content` - contains main content (inside `main#content`)
   - `body_footer` - wraps site footer container (inside `body > footer`)
     - `body_footer_content` - contains content inside site footer

--- a/src/scss/components/_global-header.scss
+++ b/src/scss/components/_global-header.scss
@@ -9,6 +9,7 @@
 
 .global-header__inner {
   @include site-width-container;
+  @include clearfix;
   padding-bottom: $baseline-grid-unit * 4;
   padding-top: $baseline-grid-unit * 4;
 
@@ -29,5 +30,23 @@
   @media(min-resolution: 192dpi) {
     background-image: url("../../assets/images/logotype-nhs-colour__reverse@2x.png");
     background-size: 79px 32px;
+  }
+
+  @include media(tablet) {
+    float: left;
+  }
+}
+
+.global-header__service-name {
+  @include core-font(16);
+  color: $grey-1;
+  display: block;
+  margin-top: $baseline-grid-unit * 2;
+
+  @include media(tablet) {
+    @include core-font(20);
+    display: inline;
+    margin-left: $baseline-grid-unit * 4;
+    margin-top: 0;
   }
 }

--- a/src/templates/nhsuk-base.njk
+++ b/src/templates/nhsuk-base.njk
@@ -48,6 +48,11 @@
               <a href="/" class="global-header__link">
                 <img src="{{ asset_path('assets/images/logotype-nhs-mono.png') }}" alt="NHS">
               </a>
+              {% block header_service_title %}
+                {% if serviceTitle %}
+                  <span class="global-header__service-name">{{ serviceTitle }}</span>
+                {% endif %}
+              {% endblock %}
             </div>
           </div>
         </header>


### PR DESCRIPTION
This adds support for a service to display its name next to the logo
in the global header.