### PR TITLE
Add `link-list` component

### DIFF
--- a/src/scss/components/link-list/_link-list.scss
+++ b/src/scss/components/link-list/_link-list.scss
@@ -1,0 +1,30 @@
+@import "../environment/tools/mixins";
+
+.link-list__row {
+  @include grid-row;
+}
+
+.link-list {
+  list-style: none;
+  padding-left: 0;
+}
+
+.link-list--numbered {
+  list-style: decimal;
+
+  .link-list__item {
+    margin-left: 1.2em;
+  }
+}
+
+.link-list--one-half {
+  @include grid-column(1 / 2);
+
+  + .link-list--one-half {
+    margin-top: $default-spacing-unit / 2;
+
+    @include media(desktop) {
+      margin-top: 0;
+    }
+  }
+}

--- a/src/scss/components/link-list/link-list.config.yaml
+++ b/src/scss/components/link-list/link-list.config.yaml
@@ -1,0 +1,8 @@
+order: 4
+variants:
+- name: half column
+  context:
+    mod: one-half
+- name: numbered
+  context:
+    mod: numbered

--- a/src/scss/components/link-list/link-list.njk
+++ b/src/scss/components/link-list/link-list.njk
@@ -1,0 +1,34 @@
+{% if mod == 'one-half' %}
+  <div class="link-list__row">
+{% endif %}
+
+  <ul class="link-list{{' link-list--' + mod if mod}}">
+    <li class="link-list__item">
+      <a href="#">Link text</a>
+    </li>
+
+    <li class="link-list__item">
+      <a href="#">Link text</a>
+    </li>
+
+    <li class="link-list__item">
+      <a href="#">Link text</a>
+    </li>
+  </ul>
+
+{% if mod == 'one-half' %}
+  <ul class="link-list{{' link-list--' + mod if mod}}">
+    <li class="link-list__item">
+      <a href="#">Link text</a>
+    </li>
+
+    <li class="link-list__item">
+      <a href="#">Link text</a>
+    </li>
+
+    <li class="link-list__item">
+      <a href="#">Link text</a>
+    </li>
+  </ul>
+</div>
+{% endif %}


### PR DESCRIPTION
This adds a new component for `link-list` which is currently
being used in the global footer and therefore, base layout.